### PR TITLE
Fix all Zig 0.15 breaking API changes

### DIFF
--- a/Chapter05/shadowing.zig
+++ b/Chapter05/shadowing.zig
@@ -1,6 +1,8 @@
 pub fn main() void {
     const pi = 3.14;
     {
-        var pi: i32 = 1234; // Error: cannot redeclare 'pi'
+        const pi2: i32 = 1234; // In Zig 0.15+, local variables cannot shadow outer scope names
+        _ = pi2;
     }
+    _ = pi;
 }

--- a/Chapter10/file_buffered_read.zig
+++ b/Chapter10/file_buffered_read.zig
@@ -11,13 +11,17 @@ pub fn main() !void {
         try f.writeAll("line1\nline2\nline3\n");
     }
 
-    const file = try cwd.openFile("log.txt", .{ .read = true });
+    const file = try cwd.openFile("log.txt", .{ .mode = .read_only });
     defer file.close();
 
     var buf: [4096]u8 = undefined;
-    var reader = file.reader();
+    var reader = file.reader(&buf);
 
-    while (try reader.readUntilDelimiterOrEof(&buf, '\n')) |line| {
+    while (true) {
+        const line = reader.interface.takeDelimiterExclusive('\n') catch |err| switch (err) {
+            error.EndOfStream => break,
+            else => return err,
+        };
         std.debug.print("Line: {s}\n", .{line});
     }
 }

--- a/Chapter10/formatting_examples.zig
+++ b/Chapter10/formatting_examples.zig
@@ -4,20 +4,23 @@ const builtin = @import("builtin");
 const Monster = struct {
     name: []const u8,
     hp: u32,
-    pub fn format(self: Monster, comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
+    pub fn format(self: Monster, writer: anytype) !void {
         try writer.print("{s} (HP: {d})", .{ self.name, self.hp });
     }
 };
 
 pub fn main() !void {
-    const stdout = std.io.getStdOut().writer();
+    var stdout_buf: [4096]u8 = undefined;
+    const stdout_file: std.fs.File = .stdout();
+    var stdout_writer = stdout_file.writer(&stdout_buf);
+    const stdout = &stdout_writer.interface;
     const allocator = std.heap.page_allocator;
 
     const name = "Goku";
     const power_level: i32 = 9001;
 
-    // Using a writer with std.fmt.format
-    try std.fmt.format(stdout, "{s}'s power level is {d}.\n", .{ name, power_level });
+    // Using a writer to print formatted output
+    try stdout.print("{s}'s power level is {d}.\n", .{ name, power_level });
 
     // allocPrint to produce a formatted owned string
     const message = try std.fmt.allocPrint(allocator, "Errors: {d}", .{42});
@@ -32,6 +35,6 @@ pub fn main() !void {
 
     // Custom format method usage
     const boss = Monster{ .name = "Dragon", .hp = 1234 };
-    // Use {} to trigger the custom format method
-    std.debug.print("Boss -> {}\n", .{boss});
+    // Use {f} to trigger the custom format method (in Zig 0.15+, {} is ambiguous for structs with format methods)
+    std.debug.print("Boss -> {f}\n", .{boss});
 }

--- a/Chapter10/formatting_mismatch_and_strings.zig
+++ b/Chapter10/formatting_mismatch_and_strings.zig
@@ -7,11 +7,9 @@ pub fn main() !void {
     // Compile-time validated format string
     std.debug.print("Player {s} scored {d} points\n", .{name, score});
 
-    //Zig's Fallback Behavior:
-    // When a type doesn’t match the format specifier, Zig tries to:
-    // - Print the raw bytes of the value (ASCII codes in this case)
-    // - Issue a runtime warning (not a compile error) about mismatched types
-    std.debug.print("Score: {d}\n", .{"100"});
-
+    // In Zig 0.15+, using a mismatched format specifier (e.g., {d} for a string)
+    // is a compile error. Always use the correct specifier for the type:
+    // - {s} for strings
+    // - {d} for integers
     std.debug.print("Score: {s}\n", .{"100"}); // Output: Score: 100
 }

--- a/Chapter13/build.zig.zon
+++ b/Chapter13/build.zig.zon
@@ -2,11 +2,11 @@
     .name = .zig_file_guard,
     .version = "0.0.0",
     .fingerprint = 0x3112a747329a3960, // Changing this has security and trust implications.
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.15.0",
     .dependencies = .{
         .args = .{
-            .url = "git+https://github.com/ikskuh/zig-args?ref=master#9425b94c103a031777fdd272c555ce93a7dea581",
-            .hash = "args-0.0.0-CiLiqv_NAAC97fGpk9hS2K681jkiqPsWP6w3ucb_ctGH",
+            .url = "git+https://github.com/ikskuh/zig-args?ref=master#e060ac80c244e9675471b6d213b22ddc83cc8f98",
+            .hash = "args-0.0.0-CiLiqo_RAADz2TiHUzG5-0Mk7IZHR-h1SZgUrb_k4c7d",
         },
     },
 

--- a/Chapter13/src/change_detection.zig
+++ b/Chapter13/src/change_detection.zig
@@ -134,7 +134,7 @@ pub const ChangeJournal = struct {
     /// Initialize a new change journal
     pub fn init(allocator: std.mem.Allocator) ChangeJournal {
         return ChangeJournal{
-            .changes = std.ArrayList(FileChange).init(allocator),
+            .changes = .{},
             .allocator = allocator,
         };
     }
@@ -144,7 +144,7 @@ pub const ChangeJournal = struct {
         for (self.changes.items) |*change| {
             change.deinit();
         }
-        self.changes.deinit();
+        self.changes.deinit(self.allocator);
     }
 
     /// Record a file change in the journal
@@ -158,7 +158,7 @@ pub const ChangeJournal = struct {
     ) !void {
         const change = try FileChange.init(self.allocator, change_type, old_path, new_path, old_metadata, new_metadata);
 
-        try self.changes.append(change);
+        try self.changes.append(self.allocator, change);
     }
 
     /// Get the number of changes in the journal
@@ -277,7 +277,7 @@ fn detectFileModifications(
 
     // Check size changes
     if (config.monitor_size) {
-        if (old_metadata.md.size() != new_metadata.md.size()) {
+        if (old_metadata.md.size != new_metadata.md.size) {
             try journal.recordChange(
                 .modified,
                 path,
@@ -291,7 +291,7 @@ fn detectFileModifications(
 
     // Check permission changes
     if (config.monitor_permissions) {
-        if (!std.meta.eql(old_metadata.md.permissions(), new_metadata.md.permissions())) {
+        if (!std.meta.eql(old_metadata.md.mode, new_metadata.md.mode)) {
             try journal.recordChange(
                 .permissions,
                 path,
@@ -305,8 +305,8 @@ fn detectFileModifications(
     // Check timestamp changes
     if (config.monitor_timestamps) {
         // Focus on modification time
-        const old_mtime = old_metadata.md.modified();
-        const new_mtime = new_metadata.md.modified();
+        const old_mtime = old_metadata.md.mtime;
+        const new_mtime = new_metadata.md.mtime;
 
         if (old_mtime != new_mtime) {
             try journal.recordChange(

--- a/Chapter13/src/cli.zig
+++ b/Chapter13/src/cli.zig
@@ -110,7 +110,10 @@ pub fn run() !void {
 
 /// Display help information
 fn showHelp(program_name: []const u8) !void {
-    const stdout = std.io.getStdOut().writer();
+    var buf: [4096]u8 = undefined;
+    const stdout_file: std.fs.File = .stdout();
+    var stdout_writer = stdout_file.writer(&buf);
+    const stdout = &stdout_writer.interface;
 
     try stdout.print("Usage: {s} [OPTIONS] [PATH]\n\n", .{program_name});
     try stdout.writeAll("A file monitoring system that detects and reports changes to the console.\n\n");
@@ -174,7 +177,10 @@ fn splitPatterns(allocator: std.mem.Allocator, patterns_str: []const u8) ![]cons
 
 /// Print a detected change to stdout
 fn printChange(change: FileChange, allocator: std.mem.Allocator) !void {
-    const stdout = std.io.getStdOut().writer();
+    var buf: [4096]u8 = undefined;
+    const stdout_file: std.fs.File = .stdout();
+    var stdout_writer = stdout_file.writer(&buf);
+    const stdout = &stdout_writer.interface;
     const old_path = change.old_path orelse "unknown";
     const new_path = change.new_path orelse "unknown";
 
@@ -204,8 +210,8 @@ fn printChange(change: FileChange, allocator: std.mem.Allocator) !void {
                 const new_meta = change.new_metadata.?;
 
                 // Size changes
-                const old_size = old_meta.md.size();
-                const new_size = new_meta.md.size();
+                const old_size = old_meta.md.size;
+                const new_size = new_meta.md.size;
 
                 if (old_size != new_size) {
                     const percentage = calculatePercentageChange(old_size, new_size);
@@ -217,12 +223,12 @@ fn printChange(change: FileChange, allocator: std.mem.Allocator) !void {
                 }
 
                 // Modified time changes (if tracked but not the only change)
-                if (old_meta.md.modified() != new_meta.md.modified() and
+                if (old_meta.md.mtime != new_meta.md.mtime and
                     change.change_type != .timestamp)
                 {
                     try stdout.print("  Modified time changed: {d} → {d}\n", .{
-                        old_meta.md.modified(),
-                        new_meta.md.modified(),
+                        old_meta.md.mtime,
+                        new_meta.md.mtime,
                     });
                 }
 
@@ -261,8 +267,8 @@ fn printChange(change: FileChange, allocator: std.mem.Allocator) !void {
 
             // Show permission details if available
             if (change.old_metadata != null and change.new_metadata != null) {
-                const old_mode = change.old_metadata.?.md.permissions();
-                const new_mode = change.new_metadata.?.md.permissions();
+                const old_mode = change.old_metadata.?.md.mode;
+                const new_mode = change.new_metadata.?.md.mode;
 
                 try stdout.print("  Mode changed: {any} → {any}\n", .{
                     old_mode,
@@ -280,8 +286,8 @@ fn printChange(change: FileChange, allocator: std.mem.Allocator) !void {
             // Show timestamp details
             if (change.old_metadata != null and change.new_metadata != null) {
                 try stdout.print("  Modified time: {d} → {d}\n", .{
-                    change.old_metadata.?.md.modified(),
-                    change.new_metadata.?.md.modified(),
+                    change.old_metadata.?.md.mtime,
+                    change.new_metadata.?.md.mtime,
                 });
             }
         },
@@ -409,7 +415,7 @@ fn runMonitor(
             if (!is_continuous) {
                 return err;
             }
-            std.time.sleep(interval_ns);
+            std.Thread.sleep(interval_ns);
             continue;
         };
 
@@ -458,7 +464,7 @@ fn runMonitor(
             break;
         }
         // Sleep for the interval
-        std.time.sleep(interval_ns);
+        std.Thread.sleep(interval_ns);
     }
 
     std.debug.print("Monitoring completed.\n", .{});

--- a/Chapter13/src/file_index.zig
+++ b/Chapter13/src/file_index.zig
@@ -62,7 +62,7 @@ pub const FileIndex = struct {
     /// - The new FileIndex is responsible for all its internal allocations
     /// - All path strings are duplicated, so both indices have independent string ownership
     /// - FileMetadata objects are cloned with duplicated path and checksum strings
-    /// - The fs.File.Metadata is copied directly (doesn't contain owned pointers)
+    /// - The fs.File.Stat is copied directly (doesn't contain owned pointers)
     ///
     /// This function maintains the relationship between paths and inodes in the cloned index.
     /// Modifying one index will not affect the other after cloning.
@@ -190,7 +190,7 @@ test "FileIndex operations" {
 
     // Retrieve by path and verify
     if (index.get(metadata.path)) |retrieved| {
-        try std.testing.expect(metadata.md.size() == retrieved.md.size());
+        try std.testing.expect(metadata.md.size == retrieved.md.size);
         try std.testing.expect(metadata.inode == retrieved.inode);
         try std.testing.expectEqualStrings(metadata.checksum.?, retrieved.checksum.?);
     } else {
@@ -274,12 +274,12 @@ test "FileIndex clone" {
     try original.addFile(metadata2);
 
     // Store original paths for later comparison
-    var originalPaths = std.ArrayList([]const u8).init(std.testing.allocator);
-    defer originalPaths.deinit();
+    var originalPaths: std.ArrayList([]const u8) = .{};
+    defer originalPaths.deinit(std.testing.allocator);
     {
         var it = original.files.keyIterator();
         while (it.next()) |key_ptr| {
-            try originalPaths.append(key_ptr.*);
+            try originalPaths.append(std.testing.allocator, key_ptr.*);
         }
     }
 
@@ -295,12 +295,12 @@ test "FileIndex clone" {
     try std.testing.expect(cloned.count() == 2);
 
     // Collect all paths from cloned index
-    var clonedPaths = std.ArrayList([]const u8).init(std.testing.allocator);
-    defer clonedPaths.deinit();
+    var clonedPaths: std.ArrayList([]const u8) = .{};
+    defer clonedPaths.deinit(std.testing.allocator);
     {
         var it = cloned.files.keyIterator();
         while (it.next()) |key_ptr| {
-            try clonedPaths.append(key_ptr.*);
+            try clonedPaths.append(std.testing.allocator, key_ptr.*);
         }
     }
 
@@ -328,7 +328,7 @@ test "FileIndex clone" {
             if (std.mem.eql(u8, orig_path, clone_path)) {
                 const clone_meta = cloned.get(clone_path).?;
 
-                try std.testing.expectEqual(orig_meta.md.size(), clone_meta.md.size());
+                try std.testing.expectEqual(orig_meta.md.size, clone_meta.md.size);
                 try std.testing.expectEqual(orig_meta.inode, clone_meta.inode);
                 try std.testing.expectEqualStrings(orig_meta.checksum.?, clone_meta.checksum.?);
                 break;

--- a/Chapter13/src/file_metadata.zig
+++ b/Chapter13/src/file_metadata.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const fs = std.fs;
 
 pub const FileMetadata = struct {
-    md: fs.File.Metadata,
+    md: fs.File.Stat,
     path: []const u8,
     inode: u64,  // unique identifier for files (helps detect moves)
     checksum: ?[]const u8, // optional content hash
@@ -18,13 +18,12 @@ pub const FileMetadata = struct {
         const file = try fs.openFileAbsolute(abs_path, .{});
         defer file.close();
 
-        const md = try fs.File.metadata(file);
-        // Get file stat information
+        // Get file stat information (replaces the old File.Metadata API)
         const stat = try file.stat();
         // Create the metadata structure
         var metadata = FileMetadata{
             .path = abs_path,
-            .md = md,
+            .md = stat,
             .inode = stat.inode,
             .checksum = null,
             .allocator = allocator,
@@ -87,7 +86,7 @@ pub const FileMetadata = struct {
     defer metadata.deinit();
 
     // Verify metadata
-        try std.testing.expect(metadata.md.size() == test_content.len);
+        try std.testing.expect(metadata.md.size == test_content.len);
     try std.testing.expect(metadata.checksum == null);
 
     // Initialize metadata (with hash)
@@ -103,7 +102,7 @@ pub const FileMetadata = struct {
     defer cloned_metadata.deinit();
 
     try std.testing.expectEqualStrings(metadata.path, cloned_metadata.path);
-    try std.testing.expect(metadata.md.size() == cloned_metadata.md.size());
+    try std.testing.expect(metadata.md.size == cloned_metadata.md.size);
     try std.testing.expect(metadata.inode == cloned_metadata.inode);
     // _ = std.debug.print("{s}\n", .{"file-metadata tests"});
     }
@@ -132,7 +131,7 @@ fn computeFileHash(file: fs.File, allocator: std.mem.Allocator) ![]const u8 {
 
     // Convert the hash to a hexadecimal string
     const hex_hash = try allocator.alloc(u8, 64);
-    _ = try std.fmt.bufPrint(hex_hash, "{s}", .{std.fmt.fmtSliceHexLower(&hash)});
+    _ = try std.fmt.bufPrint(hex_hash, "{x}", .{hash});
 
     return hex_hash;
 }


### PR DESCRIPTION
## Summary

Fixes all breaking changes from Zig 0.15 across the codebase. Tested and verified with Zig 0.15.1.

Closes #3, closes #5. Thanks to @michael-duren for reporting both issues.

## Changes

- **Chapter 5**: Fix variable shadowing (now a compile error in 0.15)
- **Chapter 10**: Update reader API (`openFile` flags, `file.reader(&buf)`, `takeDelimiterExclusive`), fix `std.io.getStdOut()` to `std.fs.File.stdout()`, update custom `format` method signature, remove invalid `{d}` for string literals
- **Chapter 13**: Replace `fs.File.Metadata` with `fs.File.Stat`, update `ArrayList` API (allocator now passed per-call), replace `std.time.sleep` with `std.Thread.sleep`, replace `std.fmt.fmtSliceHexLower` with `{x}` format, update `zig-args` dependency

## Test plan

- [x] All standalone `.zig` files with `main` compile with `zig build-exe`
- [x] Chapter 13 builds with `zig build`
- [x] Chapter 13 tests pass with `zig build test`
- [x] Chapter 7 tests pass with `zig test`