### PR TITLE
Fix: Update Ch13 args for zig v0.16

### DIFF
--- a/Chapter13/build.zig.zon
+++ b/Chapter13/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .args = .{
-            .url = "git+https://github.com/ikskuh/zig-args?ref=master#cef615b6762990466d88db126f762f1cabe327e8",
-            .hash = "args-0.0.0-CiLiqvvfAAAM3smSSA0GGjCI483ftWnhZ_FFo4WjNELF",
+            .url = "git+https://github.com/ikskuh/zig-args?ref=master#f96f325f664d4ee2cd56a17ad135b331ecb65d98",
+            .hash = "args-0.0.0-CiLiqmvgAADyJmrzcQTP9IOYNvTzR_KGrg3ZNNsH2Qv0",
         },
     },
 


### PR DESCRIPTION
Chapter 13 took a dependency on https://github.com/ikskuh/zig-args, the version used here was not compatible with zig v0.16 (the version in the build.zig.zon). 

This would cause build errors, specifically around the use of `std.fs.File` for writing to stdout, instead this updated version uses `std.io.File` and resolves all the build errors.

I pinned this to main for zig-args, but happy to point that to a different version.